### PR TITLE
Add support for custom prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,30 @@ See the module docs for `Tails` to see what we currently handle
 
 Set `config :tails, :no_merge_classes, [:foo, :bar]` to avoid merging a specific set of classes. Can be useful as an escape hatch if tails is doing the wrong thing.
 
+#### Custom Tailwind Prefix
+
+If you're using Tailwind CSS with a custom prefix (e.g., when integrating with existing CSS frameworks like Bootstrap), you can configure Tails to handle a custom prefix like so:
+
+```elixir
+# in config.exs
+config :tails, tailwind_prefix: "tw-"
+```
+
+or if using a custom tails module:
+
+```elixir
+config :my_app, MyTails, tailwind_prefix: "tw-"
+```
+
+With this configuration:
+
+```elixir
+Tails.classes(["tw-text-blue-900 tw-text-lg m-2", "p-4 tw-text-gray-700"])
+# "tw-text-lg tw-text-gray-700 tw-p-4 tw-m2"
+```
+
+This is particularly useful when you need to avoid CSS conflicts with existing stylesheets.
+
 ## Colors
 
 We use custom defined colors for two things:

--- a/lib/colors.ex
+++ b/lib/colors.ex
@@ -295,7 +295,7 @@ defmodule Tails.Colors do
     }
   }
 
-  @builtin_color_classes @builtin_colors |> Tails.ColorClasses.color_classes()
+  @builtin_color_classes @builtin_colors |> Tails.ColorClasses.color_classes("")
 
   def builtin_colors do
     @builtin_colors
@@ -308,6 +308,6 @@ defmodule Tails.Colors do
   def all_color_classes(colors) do
     @builtin_colors
     |> Map.merge(colors)
-    |> Tails.ColorClasses.color_classes()
+    |> Tails.ColorClasses.color_classes("")
   end
 end

--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -14,28 +14,6 @@ defmodule Tails.Custom do
   use Tails.Custom, otp_app: :my_app, themes: @themes
   ```
 
-  ## Configuration Options
-
-  - `:colors_file` - Path to a JSON file containing custom color definitions
-  - `:color_classes` - List of custom color class names to merge
-  - `:no_merge_classes` - List of class names to never merge
-  - `:themes` - Map of theme definitions
-  - `:dark_themes` - Map of dark theme variants
-  - `:variants` - List of custom variant names
-  - `:fallback_to_colors` - Boolean to enable fallback color matching
-  - `:tailwind_prefix` - String prefix to add to all generated classes (e.g., "tw-")
-
-  Example configuration:
-
-  ```elixir
-  config :my_app, MyTails,
-    colors_file: "assets/colors.json",
-    tailwind_prefix: "tw-",
-    color_classes: ["primary", "secondary"],
-    no_merge_classes: ["custom-class"]
-  ```
-  """
-
   defmacro __using__(opts) do
     quote location: :keep,
           generated: true,

--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -13,6 +13,27 @@ defmodule Tails.Custom do
   }
   use Tails.Custom, otp_app: :my_app, themes: @themes
   ```
+
+  ## Configuration Options
+
+  - `:colors_file` - Path to a JSON file containing custom color definitions
+  - `:color_classes` - List of custom color class names to merge
+  - `:no_merge_classes` - List of class names to never merge
+  - `:themes` - Map of theme definitions
+  - `:dark_themes` - Map of dark theme variants
+  - `:variants` - List of custom variant names
+  - `:fallback_to_colors` - Boolean to enable fallback color matching
+  - `:tailwind_prefix` - String prefix to add to all generated classes (e.g., "tw-")
+
+  Example configuration:
+
+  ```elixir
+  config :my_app, MyTails,
+    colors_file: "assets/colors.json",
+    tailwind_prefix: "tw-",
+    color_classes: ["primary", "secondary"],
+    no_merge_classes: ["custom-class"]
+  ```
   """
 
   defmacro __using__(opts) do
@@ -34,6 +55,7 @@ defmodule Tails.Custom do
         @themes themes || Application.compile_env(otp_app, :themes)
         @custom_variants Application.compile_env(otp_app, :variants) || []
         @fallback_to_colors Application.compile_env(otp_app, :fallback_to_colors) || false
+        @tailwind_prefix Application.compile_env(otp_app, :tailwind_prefix) || ""
       else
         @colors_file Application.compile_env(otp_app, __MODULE__)[:colors_file]
         @color_classes Application.compile_env(otp_app, __MODULE__)[:color_classes] || []
@@ -43,6 +65,7 @@ defmodule Tails.Custom do
         @custom_variants Application.compile_env(otp_app, __MODULE__)[:variants] || []
         @fallback_to_colors Application.compile_env(otp_app, __MODULE__)[:fallback_to_colors] ||
                               false
+        @tailwind_prefix Application.compile_env(otp_app, __MODULE__)[:tailwind_prefix] || ""
       end
 
       @colors (if @colors_file do
@@ -415,6 +438,20 @@ defmodule Tails.Custom do
 
       @browser_color_prefixes ~w[# rgb( rgba( hsl( hsla(]
 
+      defp strip_prefix(class) when is_binary(class) do
+        case @tailwind_prefix do
+          "" ->
+            class
+
+          prefix ->
+            if String.starts_with?(class, prefix) do
+              String.slice(class, String.length(prefix)..-1//1)
+            else
+              class
+            end
+        end
+      end
+
       @moduledoc """
       Tailwind class utilities like class merging.
 
@@ -697,7 +734,7 @@ defmodule Tails.Custom do
       def merge(tailwind, classes) when is_binary(classes) do
         classes
         |> String.split()
-        |> Enum.reduce(tailwind, &merge_class(&2, &1))
+        |> Enum.reduce(tailwind, &merge_class(&2, strip_prefix(&1)))
       end
 
       def merge(tailwind, %__MODULE__{} = classes) do
@@ -1426,9 +1463,26 @@ defmodule Tails.Custom do
                 []
               else
                 if variant do
-                  [" " | Enum.intersperse(Enum.map(tailwind.classes, &[variant, ":", &1]), " ")]
+                  [
+                    " "
+                    | Enum.intersperse(
+                        Enum.map(tailwind.classes, &add_prefix_to_iodata([variant, ":", &1])),
+                        " "
+                      )
+                  ]
                 else
-                  [" " | Enum.intersperse(tailwind.classes, " ")]
+                  [
+                    " "
+                    | Enum.intersperse(
+                        Enum.map(tailwind.classes, fn class ->
+                          case @tailwind_prefix do
+                            "" -> class
+                            prefix -> prefix <> class
+                          end
+                        end),
+                        " "
+                      )
+                  ]
                 end
               end
           end
@@ -1436,18 +1490,29 @@ defmodule Tails.Custom do
       end
 
       defp simple(nil, _), do: ""
-      defp simple(value, nil), do: [" ", value]
-      defp simple(value, variant), do: [" ", variant, ":", value]
+      defp simple(value, nil), do: [" " | add_prefix_to_iodata([value])]
+      defp simple(value, variant), do: [" " | add_prefix_to_iodata([variant, ":", value])]
+
+      defp add_prefix_to_iodata(iodata) do
+        case @tailwind_prefix do
+          "" -> iodata
+          prefix -> [prefix | iodata]
+        end
+      end
 
       defp prefix(prefix, value, variant, naked? \\ false)
       defp prefix(_prefix, nil, _, _), do: ""
-      defp prefix(prefix, empty, nil, true) when empty in ["", nil], do: [" ", prefix]
-      defp prefix(prefix, value, nil, _), do: [" ", prefix, "-", value]
+
+      defp prefix(prefix, empty, nil, true) when empty in ["", nil],
+        do: [" " | add_prefix_to_iodata([prefix])]
+
+      defp prefix(prefix, value, nil, _), do: [" " | add_prefix_to_iodata([prefix, "-", value])]
 
       defp prefix(prefix, empty, variant, true) when empty in ["", nil],
-        do: [" ", variant, ":", prefix]
+        do: [" " | add_prefix_to_iodata([variant, ":", prefix])]
 
-      defp prefix(prefix, value, variant, _), do: [" ", variant, ":", prefix, "-", value]
+      defp prefix(prefix, value, variant, _),
+        do: [" " | add_prefix_to_iodata([variant, ":", prefix, "-", value])]
 
       defp directional(nil, _key, _, _), do: ""
 
@@ -1488,19 +1553,41 @@ defmodule Tails.Custom do
       defp direction(nil, _, _, _, _), do: ""
 
       defp direction("", suffix, prefix, nil, dash_suffix?),
-        do: [" ", prefix, dash_suffix(suffix, dash_suffix?)]
+        do: [" " | add_prefix_to_iodata([prefix, dash_suffix(suffix, dash_suffix?)])]
 
       defp direction("-" <> value, suffix, prefix, nil, dash_suffix?),
-        do: [" -", prefix, dash_suffix(suffix, dash_suffix?), "-", value]
+        do: [
+          " " | add_prefix_to_iodata(["-", prefix, dash_suffix(suffix, dash_suffix?), "-", value])
+        ]
 
       defp direction(value, suffix, prefix, nil, dash_suffix?),
-        do: [" ", prefix, dash_suffix(suffix, dash_suffix?), "-", value]
+        do: [" " | add_prefix_to_iodata([prefix, dash_suffix(suffix, dash_suffix?), "-", value])]
 
       defp direction("-" <> value, suffix, prefix, variant, dash_suffix?),
-        do: [" ", variant, ":-", prefix, dash_suffix(suffix, dash_suffix?), "-", value]
+        do: [
+          " "
+          | add_prefix_to_iodata([
+              variant,
+              ":-",
+              prefix,
+              dash_suffix(suffix, dash_suffix?),
+              "-",
+              value
+            ])
+        ]
 
       defp direction(value, suffix, prefix, variant, dash_suffix?),
-        do: [" ", variant, ":", prefix, dash_suffix(suffix, dash_suffix?), "-", value]
+        do: [
+          " "
+          | add_prefix_to_iodata([
+              variant,
+              ":",
+              prefix,
+              dash_suffix(suffix, dash_suffix?),
+              "-",
+              value
+            ])
+        ]
 
       defp dash_suffix(value, true) when not is_nil(value), do: ["-", value]
       defp dash_suffix(nil, _), do: ""

--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -13,6 +13,7 @@ defmodule Tails.Custom do
   }
   use Tails.Custom, otp_app: :my_app, themes: @themes
   ```
+  """
 
   defmacro __using__(opts) do
     quote location: :keep,

--- a/lib/custom.ex
+++ b/lib/custom.ex
@@ -1445,7 +1445,9 @@ defmodule Tails.Custom do
                   [
                     " "
                     | Enum.intersperse(
-                        Enum.map(tailwind.classes, &add_prefix_to_iodata([variant, ":", &1])),
+                        Enum.map(tailwind.classes, fn class ->
+                          [variant, ":", class]
+                        end),
                         " "
                       )
                   ]
@@ -1470,7 +1472,7 @@ defmodule Tails.Custom do
 
       defp simple(nil, _), do: ""
       defp simple(value, nil), do: [" " | add_prefix_to_iodata([value])]
-      defp simple(value, variant), do: [" " | add_prefix_to_iodata([variant, ":", value])]
+      defp simple(value, variant), do: [" ", variant, ":" | add_prefix_to_iodata([value])]
 
       defp add_prefix_to_iodata(iodata) do
         case @tailwind_prefix do
@@ -1488,10 +1490,10 @@ defmodule Tails.Custom do
       defp prefix(prefix, value, nil, _), do: [" " | add_prefix_to_iodata([prefix, "-", value])]
 
       defp prefix(prefix, empty, variant, true) when empty in ["", nil],
-        do: [" " | add_prefix_to_iodata([variant, ":", prefix])]
+        do: [" ", variant, ":" | add_prefix_to_iodata([prefix])]
 
       defp prefix(prefix, value, variant, _),
-        do: [" " | add_prefix_to_iodata([variant, ":", prefix, "-", value])]
+        do: [" ", variant, ":" | add_prefix_to_iodata([prefix, "-", value])]
 
       defp directional(nil, _key, _, _), do: ""
 
@@ -1544,10 +1546,7 @@ defmodule Tails.Custom do
 
       defp direction("-" <> value, suffix, prefix, variant, dash_suffix?),
         do: [
-          " "
-          | add_prefix_to_iodata([
-              variant,
-              ":-",
+          " ", variant, ":-" | add_prefix_to_iodata([
               prefix,
               dash_suffix(suffix, dash_suffix?),
               "-",
@@ -1557,10 +1556,7 @@ defmodule Tails.Custom do
 
       defp direction(value, suffix, prefix, variant, dash_suffix?),
         do: [
-          " "
-          | add_prefix_to_iodata([
-              variant,
-              ":",
+          " ", variant, ":" | add_prefix_to_iodata([
               prefix,
               dash_suffix(suffix, dash_suffix?),
               "-",


### PR DESCRIPTION
Support for custom prefixes

README snippet below: 👇🏻
---
#### Custom Tailwind Prefix

If you're using Tailwind CSS with a custom prefix (e.g., when integrating with existing CSS frameworks like Bootstrap), you can configure Tails to handle a custom prefix like so:

```elixir
# in config.exs
config :tails, tailwind_prefix: "tw-"
```

or if using a custom tails module:

```elixir
config :my_app, MyTails, tailwind_prefix: "tw-"
```

With this configuration:

```elixir
Tails.classes(["tw-text-blue-900 tw-text-lg m-2", "p-4 tw-text-gray-700"])
# "tw-text-lg tw-text-gray-700 tw-p-4 tw-m2"
```

This is particularly useful when you need to avoid CSS conflicts with existing stylesheets.

